### PR TITLE
Custom base path

### DIFF
--- a/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
+++ b/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
@@ -19,9 +19,17 @@ class TemporaryFilesystem implements TemporaryFilesystemInterface
     /** @var Filesystem */
     private $filesystem;
 
-    public function __construct(Filesystem $filesystem)
+    /** @var string */
+    private $basePath;
+
+    public function __construct(Filesystem $filesystem, $basePath = null)
     {
         $this->filesystem = $filesystem;
+
+        if (null === $basePath) {
+            $basePath = sys_get_temp_dir();
+        }
+        $this->basePath = $basePath;
     }
 
     /**
@@ -29,7 +37,7 @@ class TemporaryFilesystem implements TemporaryFilesystemInterface
      */
     public function createTemporaryDirectory($mode = 0777, $maxTry = 65536, $prefix = null)
     {
-        $basePath = sys_get_temp_dir();
+        $basePath = $this->basePath;
 
         while ($maxTry > 0) {
             $dir = $basePath . DIRECTORY_SEPARATOR
@@ -123,8 +131,8 @@ class TemporaryFilesystem implements TemporaryFilesystemInterface
      *
      * @return TemporaryFilesystem
      */
-    public static function create()
+    public static function create($basePath = null)
     {
-        return new static(new Filesystem());
+        return new static(new Filesystem(), $basePath);
     }
 }

--- a/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
+++ b/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
@@ -71,7 +71,7 @@ class TemporaryFilesystem implements TemporaryFilesystemInterface
         $files = array();
 
         while ($quantity > 0) {
-            $files[] = $this->createEmptyFile(sys_get_temp_dir(), $prefix, $suffix, $extension, $maxTry);
+            $files[] = $this->createEmptyFile($this->basePath, $prefix, $suffix, $extension, $maxTry);
             $quantity --;
         }
 

--- a/tests/Neutron/TemporaryFilesystem/Tests/CustomBasePathTest.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/CustomBasePathTest.php
@@ -21,4 +21,10 @@ class CustomBasePathTest extends TestCase
         $dir = $this->filesystem->createTemporaryDirectory();
         $this->assertStringStartsWith(DEV_VAR_DIR, $dir);
     }
+
+    public function testTemporaryFile()
+    {
+        $file = $this->filesystem->createTemporaryFile();
+        $this->assertStringStartsWith(DEV_VAR_DIR, $file);
+    }
 }

--- a/tests/Neutron/TemporaryFilesystem/Tests/CustomBasePathTest.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/CustomBasePathTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Neutron\TemporaryFilesystem\Tests;
+
+use Neutron\TemporaryFilesystem\TemporaryFilesystem;
+
+class CustomBasePathTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->workspace = DEV_VAR_DIR.DIRECTORY_SEPARATOR.time().mt_rand(0, 1000);
+        mkdir($this->workspace, 0777, true);
+        $this->workspace = realpath($this->workspace);
+        $this->filesystem = TemporaryFilesystem::create($this->workspace);
+    }
+
+    public function testCreateTemporaryDir()
+    {
+        $dir = $this->filesystem->createTemporaryDirectory();
+        $this->assertStringStartsWith(DEV_VAR_DIR, $dir);
+    }
+}

--- a/tests/Neutron/TemporaryFilesystem/Tests/TemporaryFilesystemTest.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/TemporaryFilesystemTest.php
@@ -5,18 +5,8 @@ namespace Neutron\TemporaryFilesystem\Tests;
 use Neutron\TemporaryFilesystem\TemporaryFilesystem;
 use Symfony\Component\Filesystem\Filesystem;
 
-class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
+class TemporaryFilesystemTest extends TestCase
 {
-    /**
-     * @var string $workspace
-     */
-    private $workspace = null;
-
-    /**
-     * @var TemporaryFilesystem
-     */
-    private $filesystem;
-
     public function setUp()
     {
         parent::setUp();
@@ -27,11 +17,6 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
         $this->filesystem = TemporaryFilesystem::create();
     }
 
-    public function tearDown()
-    {
-        $this->clean($this->workspace);
-    }
-
     public function testCreate()
     {
         $this->assertInstanceOf('Neutron\TemporaryFilesystem\TemporaryFilesystem', TemporaryFilesystem::create());
@@ -40,23 +25,6 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
     public function testConctruct()
     {
         $this->assertInstanceOf('Neutron\TemporaryFilesystem\TemporaryFilesystem', new TemporaryFilesystem(new Filesystem()));
-    }
-
-    /**
-     * @param string $file
-     */
-    private function clean($file)
-    {
-        if (is_dir($file) && !is_link($file)) {
-            $dir = new \FilesystemIterator($file);
-            foreach ($dir as $childFile) {
-                $this->clean($childFile);
-            }
-
-            rmdir($file);
-        } else {
-            unlink($file);
-        }
     }
 
     /**

--- a/tests/Neutron/TemporaryFilesystem/Tests/TestCase.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/TestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Neutron\TemporaryFilesystem\Tests;
+
+use Neutron\TemporaryFilesystem\TemporaryFilesystem;
+
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string $workspace
+     */
+    protected $workspace = null;
+
+    /**
+     * @var TemporaryFilesystem
+     */
+    protected $filesystem;
+
+    public function tearDown()
+    {
+        $this->clean($this->workspace);
+    }
+
+    /**
+     * @param string $file
+     */
+    protected function clean($file)
+    {
+        if (is_dir($file) && !is_link($file)) {
+            $dir = new \FilesystemIterator($file);
+            foreach ($dir as $childFile) {
+                $this->clean($childFile);
+            }
+
+            rmdir($file);
+        } else {
+            unlink($file);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,5 @@
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
 $loader->add('Neutron\TemporaryFilesystem\Tests', __DIR__ . '/../tests');
+
+define('DEV_VAR_DIR', realpath(__DIR__ . '/../var'));


### PR DESCRIPTION
I have a use case where I could use the functionality of this package (create dirs/files without naming collisions) outside the system's temp dir. So I introduced an optional constructor parameter to inject a custom base path.

What do you think? Might this be useful for others?