### PR TITLE
Add rtrim for sys_get_temp_dir

### DIFF
--- a/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
+++ b/src/Neutron/TemporaryFilesystem/TemporaryFilesystem.php
@@ -30,6 +30,8 @@ class TemporaryFilesystem implements TemporaryFilesystemInterface
     public function createTemporaryDirectory($mode = 0777, $maxTry = 65536, $prefix = null)
     {
         $basePath = sys_get_temp_dir();
+        // Remove trailing slashes if present
+        $basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
 
         while ($maxTry > 0) {
             $dir = $basePath . DIRECTORY_SEPARATOR


### PR DESCRIPTION
In case of trailing slashes we need to remove them, since the rest of the code assumes no trailing slashes.

This is a solution to issue #6 