### PR TITLE
Add support for Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false
@@ -29,6 +30,8 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*@dev
+    - php: 7.1
+      env: SYMFONY_VERSION=4.*
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -20,6 +17,9 @@ env:
 matrix:
   include:
     - php: 5.6
+      env: COMPOSER_FLAGS="--prefer-lowest"
+           SYMFONY_VERSION=2.*
+    - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
@@ -29,8 +29,6 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*@dev
-    - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.9 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/filesystem": "^2.3 || ^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/filesystem": "^2.3 || ^3.0"
+        "symfony/filesystem": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^5.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Neutron/TemporaryFilesystem/TemporaryFilesystemInterface.php
+++ b/src/Neutron/TemporaryFilesystem/TemporaryFilesystemInterface.php
@@ -11,8 +11,6 @@
 
 namespace Neutron\TemporaryFilesystem;
 
-use Symfony\Component\Filesystem\Exception\IOException;
-
 interface TemporaryFilesystemInterface
 {
     /**


### PR DESCRIPTION
This patch adds support for Symfony 4 on PHP 7.1. As Travis does no longer support older versions of PHP, I dropped them from the build matrix.

Supersedes: #8 
Fixes: #9