### PR TITLE
Fix phpunit tests compatibility and Symfony 5 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 composer.phar
 composer.lock
+.phpunit.result.cache
+/tests/phpunit_report/

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ before_install:
 install: composer update --prefer-source $COMPOSER_FLAGS
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/filesystem": "^2.3 || ^3.0 || ^4.0"
+        "symfony/filesystem": "^2.3 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "symfony/phpunit-bridge": "^5.0.4"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,23 +7,19 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="false"
          bootstrap="tests/bootstrap.php"
 >
     <logging>
-      <log type="coverage-html" target="tests/phpunit_report/report" charset="UTF-8"
-           yui="true" highlight="false"
+      <log type="coverage-html"
+           target="tests/phpunit_report/report"
            lowUpperBound="35" highLowerBound="70"/>
     </logging>
+
     <php>
       <ini name="display_errors" value="on"/>
+      <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="true"/>
     </php>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 
     <testsuites>
         <testsuite name="TemporaryFilesystem tests Suite">
@@ -31,11 +27,9 @@
         </testsuite>
     </testsuites>
     <filter>
-      <blacklist>
-        <directory>vendor</directory>
-        <directory>tests</directory>
-      </blacklist>
+      <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">src/</directory>
+      </whitelist>
     </filter>
-
 </phpunit>
 

--- a/tests/Neutron/TemporaryFilesystem/Tests/ManagerTest.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/ManagerTest.php
@@ -3,8 +3,9 @@
 namespace Neutron\TemporaryFilesystem\Tests;
 
 use Neutron\TemporaryFilesystem\Manager;
+use PHPUnit\Framework\TestCase;
 
-class ManagerTest extends \PHPUnit_Framework_TestCase
+class ManagerTest extends TestCase
 {
     public function testCreateEmptyFileAndCleanScope()
     {
@@ -288,7 +289,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
     private function createTmpFsMock()
     {
-        return $this->getMock('Neutron\TemporaryFilesystem\TemporaryFilesystemInterface');
+        return $this->getMockBuilder('Neutron\TemporaryFilesystem\TemporaryFilesystemInterface')->getMock();
     }
 
     private function createFsMock()

--- a/tests/Neutron/TemporaryFilesystem/Tests/TemporaryFilesystemTest.php
+++ b/tests/Neutron/TemporaryFilesystem/Tests/TemporaryFilesystemTest.php
@@ -2,10 +2,12 @@
 
 namespace Neutron\TemporaryFilesystem\Tests;
 
+use Neutron\TemporaryFilesystem\IOException;
 use Neutron\TemporaryFilesystem\TemporaryFilesystem;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
+class TemporaryFilesystemTest extends TestCase
 {
     /**
      * @var string $workspace
@@ -88,7 +90,7 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
         $dir = $this->filesystem->createTemporaryDirectory(0777, 200, 'neutron');
         $this->assertTrue(file_exists($dir));
         $this->assertTrue(is_dir($dir));
-        $this->assertContains('neutron', $dir);
+        $this->assertStringContainsString('neutron', $dir);
         rmdir($dir);
     }
 
@@ -105,53 +107,48 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testCreateEmptyFileInvalidDir()
     {
+        $this->expectException(IOException::class);
+
         $createDir = $this->workspace . DIRECTORY_SEPARATOR . 'invalid-book-dir';
 
         $this->filesystem->createEmptyFile($createDir);
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testCreateEmptyFileInvalidDirSecondMethod()
     {
+        $this->expectException(IOException::class);
+
         $createDir = $this->workspace . DIRECTORY_SEPARATOR . 'invalid-book-dir';
 
         $this->filesystem->createEmptyFile($createDir, 'romain', 'neutron');
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testCreateEmptyFileFails()
     {
+        $this->expectException(IOException::class);
+
         $createDir = $this->workspace . DIRECTORY_SEPARATOR . 'book-dir';
         mkdir($createDir);
 
         $this->filesystem->createEmptyFile($createDir, 'romain', 'neutron', null, 0);
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testCreateEmptyFileOnFile()
     {
+        $this->expectException(IOException::class);
+
         $createDir = $this->workspace . DIRECTORY_SEPARATOR . 'book-dir';
         touch($createDir);
 
         $this->filesystem->createEmptyFile($createDir, null, null, null);
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testCreateEmptyFileOnFileSecondMethod()
     {
+        $this->expectException(IOException::class);
+
         $createDir = $this->workspace . DIRECTORY_SEPARATOR . 'book-dir';
         touch($createDir);
 
@@ -180,7 +177,7 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
     public function testTemporaryFile($prefix, $suffix, $extension, $maxTry, $pattern)
     {
         $file = $this->filesystem->createTemporaryFile($prefix, $suffix, $extension, $maxTry);
-        $this->assertInternalType('string', $file);
+        $this->assertIsString($file);
 
         $this->assertTrue(file_exists($file));
         $this->assertEquals(realpath(sys_get_temp_dir()), realpath(dirname($file)));
@@ -188,19 +185,17 @@ class TemporaryFilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp($pattern, basename($file));
     }
 
-    /**
-     * @expectedException Neutron\TemporaryFilesystem\IOException
-     */
     public function testTemporaryFilesFails()
     {
+        $this->expectException(IOException::class);
+
         $this->filesystem->createTemporaryFiles(3, 'prefix', 'suffix', null, 0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTemporaryFilesInvalidQuantity()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->filesystem->createTemporaryFiles(0);
     }
 }


### PR DESCRIPTION
To support this wide range of php versions the phpunit bridge is needed use the correct phpunit version for the used php version.